### PR TITLE
Add the "mailto:" scheme to the security email address in security.txt

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,4 +1,4 @@
 #Details: https://scotthelme.co.uk/say-hello-to-security-txt/
-Contact: security@scotthelme.co.uk
+Contact: mailto:security@scotthelme.co.uk
 Contact: https://twitter.com/Scott_Helme
 Encryption: https://scotthelme.co.uk/contact/


### PR DESCRIPTION
Hi Scott,

I was reading about `security.txt`, including your article [Say hello to security.txt](https://scotthelme.co.uk/say-hello-to-security-txt/) when I noticed this small detail in the `security.txt` on your website. The [current version of the draft standard specifies](https://tools.ietf.org/html/draft-foudil-securitytxt-09#section-3.5.3):

> The value MUST follow the URI syntax described in [[RFC3986](https://tools.ietf.org/html/rfc3986)].  This means that "mailto" and "tel" URI schemes must be used when specifying email addresses and telephone numbers, as defined in [[RFC6068](https://tools.ietf.org/html/rfc6068)] and [[RFC3966](https://tools.ietf.org/html/rfc3966)].

[securityheaders.com](https://securityheaders.com/.well-known/security.txt) seems to be missing the scheme as well, [report-uri.com](https://report-uri.com/.well-known/security.txt) is correct however.
I know, it's a small detail, but I happened to notice this repository coming by in my GitHub feed so I figured I'd create a pull request as a thank you for all the work you're doing for the security community :wink: